### PR TITLE
Encode ☰ to &#9776 to fix bug with webapp

### DIFF
--- a/index.html
+++ b/index.html
@@ -275,7 +275,7 @@ path {
 </style>
 </head>
 <body>
-    <div class="menubtn">☰</div>
+    <div class="menubtn">&#9776</div>
     <ul class="menu">
       <li onclick="newProject()">New</li>
       <li onclick="board.save()">Save image</li>


### PR DESCRIPTION
I hosted the repo locally, and the menu bar showed up as â~(degrees symbol), but this fixed it.