### PR TITLE
fix: use relative paths in manifest.json

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -4,16 +4,16 @@
   "prefer_related_applications": false,
   "icons": [
     {
-      "src":"/icons/logo.png",
+      "src":"./icons/logo.png",
       "sizes": "192x192",
       "type": "image/png"
     },{
-      "src":"/icons/logo.png",
+      "src":"./icons/logo.png",
       "sizes": "512x512",
       "type": "image/png"
     }
   ],
-  "start_url": "/",
+  "start_url": ".",
   "background_color": "#ffffff",
   "Theme_color": "#ffffff",
   "display": "standalone"


### PR DESCRIPTION
Currently this app is deployed to 2 locations: https://pixelcraft.web.app/ and https://rgab1508.github.io/PixelCraft/

The manifest file works (i.e. PWA is installable) for the first url, but it doesn't work for the second url because of the path references in manifest.json.

This PR fixes the paths in manifest.json and make it work in both locations.

demo: https://kt3k.github.io/PixelCraft/

You can validate the manifest file in `Lighthouse` panel of chrome devtools, for example. If the manifest is not valid, then the panel shows the error like the below:

<img width="719" alt="スクリーンショット 2022-04-03 18 28 38" src="https://user-images.githubusercontent.com/613956/161421032-9a3ec120-0e4d-49b2-a854-ae979e990671.png">


